### PR TITLE
Release 1.1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,10 @@
 name: test
 
-on: 
+on:
   push:
-  workflow_dispatch:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:
@@ -11,14 +13,23 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-
     steps:
-      - uses: actions/checkout@v4
-
-      - name: install virtual env
-        run: |
-          pip install virtualenv
-          
-      - name: make test
-        run: |
-          make test
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=100 --statistics
+    - name: Test with pytest
+      run: |
+        PYTHONPATH=src/ pytest --doctest-modules --doctest-continue-on-failure

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Funnel
+Copyright (c) 2021-2024 Funnel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,19 @@
-setup: venv
+PYTHON_VERSION ?= 3.9
 
 dist: clean-dist venv
 	. venv/bin/activate && python3 -m build .
 
-venv: dev-requirements.txt
+.PHONY: setup
+setup: venv/setup.txt
+
+venv:
 	virtualenv venv --python=${PYTHON_VERSION}
+
+venv/setup.txt: venv dev-requirements.txt
 	. venv/bin/activate && \
 	pip3 install --upgrade pip && \
-	pip3 install \
-	--requirement dev-requirements.txt
+	pip3 install --requirement dev-requirements.txt
+	touch venv/setup.txt
 
 .PHONY: clean
 clean: clean-dist
@@ -21,13 +26,21 @@ clean-dist:
 	rm -rf dist
 
 .PHONY: test
-test: venv
+test: setup
 	@ . venv/bin/activate && PYTHONPATH=src/ pytest -vv -rsx tests/ src/ --cov ./src/json_normalize/ --no-cov-on-fail --cov-report term-missing --doctest-modules --doctest-continue-on-failure
 	@ . venv/bin/activate && flake8 src --exclude '#*,~*,.#*'
 	@ . venv/bin/activate && black --check src/ tests/
 
 .PHONY: test-focus
-test-focus: venv
+test-focus: setup
 	@ . venv/bin/activate && PYTHONPATH=src/ pytest -vv -m focus -rsx tests/ src/ --cov ./src/json_normalize/ --no-cov-on-fail --cov-report term-missing --doctest-modules --doctest-continue-on-failure
 	@ . venv/bin/activate && flake8 src --exclude '#*,~*,.#*'
 	@ . venv/bin/activate && black --check src/ tests/
+
+.PHONY: release
+release: test dist
+	. venv/bin/activate && twine upload dist/*
+
+.PHONY: test-release
+test-release: test dist
+	. venv/bin/activate && twine upload -r testpypi dist/*

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ This package contains a function, json_normalize. It will take a json-like struc
 
 Data association will flows up and down inside dicts although in iterables, e.g. lists, data
 
+## Installation
+
+Install the package `json_normalize` version `1.1+` from PyPI.  
+The recommended `requirements.txt` line is `json_normalize~=1.1`.
+
 ## json_normalize.json_normalize
 
 ```python

--- a/src/json_normalize/__init__.py
+++ b/src/json_normalize/__init__.py
@@ -6,6 +6,6 @@ __all__ = [
     "last_node_name",
 ]
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 
 VERSION = __version__

--- a/src/json_normalize/__init__.py
+++ b/src/json_normalize/__init__.py
@@ -2,8 +2,8 @@ from .main import json_normalize
 from .key_joiners import last_node_name
 
 __all__ = [
-    json_normalize,
-    last_node_name,
+    "json_normalize",
+    "last_node_name",
 ]
 
 __version__ = "1.0.1"


### PR DESCRIPTION
* Drop Python 3.7 support
* Fix `__all__` to contain strings.
* Bump copyright year range.
